### PR TITLE
Embeddings for cdk

### DIFF
--- a/embeddings/entry_point.py
+++ b/embeddings/entry_point.py
@@ -1,0 +1,37 @@
+"""
+Entry point script for document embedding and upload to index
+Depending on the value of the SSM Parameter '/student-advising/dev/retriever/RETRIEVER_NAME',
+will upload embedded documents either to Pinecone or RDS
+
+Requires that the associated secret credentials are supplied in secrets manager:
+- Pinecone: student-advising/dev/retriever/PINECONE
+    - keys: PINECONE_KEY, PINECONE_REGION
+- RDS: student-advising/credentials/RDSCredentials
+
+Note: If using for RDS, this must be run within the same VPC
+"""
+import subprocess
+import torch
+import sys
+sys.path.append('..')
+from aws_helpers.param_manager import get_param_manager
+
+RETRIEVER_CONFIG_SSM_KEY = "retriever"
+RETRIEVER_NAME_SSM_KEY = "RETRIEVER_NAME"
+
+param_manager = get_param_manager()
+retriever_config = param_manager.get_parameter('retriever')
+retriever_name = retriever_config[RETRIEVER_NAME_SSM_KEY]
+
+args = ["--compute_embeddings", "--clear_index"]
+if torch.cuda.is_available():
+    args.append("--gpu_available")
+else:
+    args.append("--no-gpu_available")
+
+if retriever_name == "pinecone":
+    subprocess.run(["python", "pinecone_combined_script.py", *args])
+elif retriever_name == "pgvector":
+    subprocess.run(["python", "rds_combined_script.py", *args])
+else:
+    raise ValueError(f"Unsupported retriever type '{retriever_name}', supported types are 'pinecone' and 'pgvector'.")

--- a/embeddings/rds_combined_script.py
+++ b/embeddings/rds_combined_script.py
@@ -51,6 +51,8 @@ parser.add_argument('--no-gpu_available', dest='gpu_available', action='store_fa
 parser.set_defaults(gpu_available=True)
 args = parser.parse_args()
 
+print(args)
+
 ### DOCUMENT LOADING 
 
 # Load the csv of documents from s3

--- a/embeddings/requirements.txt
+++ b/embeddings/requirements.txt
@@ -1,0 +1,15 @@
+# General requirements
+huggingface_hub 
+transformers
+langchain==0.0.240
+pandas
+sentence-transformers
+python-dotenv
+
+# PGVector requirements
+pgvector
+psycopg2-binary
+
+# Pinecone requirements
+pinecone-client
+pinecone-text


### PR DESCRIPTION
Add entry point and requirements for a docker image to run embeddings, as deployable by cdk (rather than running by jupyter notebook)